### PR TITLE
Add `queries.xml` files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# CodeQL compilation caches
+.cache/

--- a/codeql-custom-queries-cpp/queries.xml
+++ b/codeql-custom-queries-cpp/queries.xml
@@ -1,0 +1,1 @@
+<queries language="cpp"/>

--- a/codeql-custom-queries-csharp/queries.xml
+++ b/codeql-custom-queries-csharp/queries.xml
@@ -1,0 +1,1 @@
+<queries language="csharp"/>

--- a/codeql-custom-queries-go/queries.xml
+++ b/codeql-custom-queries-go/queries.xml
@@ -1,0 +1,1 @@
+<queries language="go"/>

--- a/codeql-custom-queries-java/queries.xml
+++ b/codeql-custom-queries-java/queries.xml
@@ -1,0 +1,1 @@
+<queries language="java"/>

--- a/codeql-custom-queries-javascript/queries.xml
+++ b/codeql-custom-queries-javascript/queries.xml
@@ -1,0 +1,1 @@
+<queries language="javascript"/>

--- a/codeql-custom-queries-python/queries.xml
+++ b/codeql-custom-queries-python/queries.xml
@@ -1,0 +1,1 @@
+<queries language="python"/>


### PR DESCRIPTION
Supports compilation caching in the current version of the CodeQL tools.
As suggested by @lcartey.
cc @alexet 