### PR TITLE
Add default extension for remove development

### DIFF
--- a/vscode-codeql-starter.code-workspace
+++ b/vscode-codeql-starter.code-workspace
@@ -28,6 +28,9 @@
 	"settings": {
 		"ql.distribution.includePrerelease": true,
 		"ql.distribution.owner": "github",
-		"ql.distribution.repository": "codeql-cli-binaries"
+		"ql.distribution.repository": "codeql-cli-binaries",
+		"remote.containers.defaultExtensions": [
+			"github.vscode-codeql"
+		]
 	}
 }


### PR DESCRIPTION
Ensures the codeql extension is always installed when doing remote development.