### PR TITLE
Remove unused settings and disable updating to prereleases of the CodeQL CLI by default

### DIFF
--- a/vscode-codeql-starter.code-workspace
+++ b/vscode-codeql-starter.code-workspace
@@ -24,10 +24,5 @@
 		{
 			"path": "ql"
 		}
-	],
-	"settings": {
-		"ql.distribution.includePrerelease": true,
-		"ql.distribution.owner": "github",
-		"ql.distribution.repository": "codeql-cli-binaries"
-	}
+	]
 }


### PR DESCRIPTION
Remove `ql.distribution.owner` and `ql.distribution.repository` settings from the workspace since they are unused, and remove the `ql.distribution.includePrereleases` setting to disable including prereleases by default.