### PR TITLE
Turn off C# auto-compile

### DIFF
--- a/vscode-codeql-starter.code-workspace
+++ b/vscode-codeql-starter.code-workspace
@@ -24,5 +24,8 @@
 		{
 			"path": "ql"
 		}
-	]
+	],
+	"settings": {
+		"omnisharp.autoStart": false
+	}
 }


### PR DESCRIPTION
If the C# extension is installed, then it reports 25k+ errors on the C# extractor until it is properly built. This is pure noise for the users of this repo, so this commit disables the C# compilation altogether.