### PR TITLE
Update devcontainer memory settings

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,5 +3,8 @@
     "github.vscode-codeql",
     "slevesque.vscode-zipexplorer"
   ],
-  "postCreateCommand": "git submodule init && git submodule update --recursive"
+  "postCreateCommand": "git submodule init && git submodule update --recursive",
+  "settings": {
+    "codeQL.runningQueries.memory": 2048
+  }
  }


### PR DESCRIPTION
CodeQL CLI needs a minimum of 2G of memory. By default, the memory used
is slightly less than that, leading to poor performance.