### PR TITLE
Update github/codeql submodule URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "ql"]
 	path = ql
-	url = https://github.com/Semmle/ql.git
+	url = https://github.com/github/codeql.git
 	branch = lgtm.com
 [submodule "codeql-go"]
 	path = codeql-go


### PR DESCRIPTION
No behaviour change, since the old repository name already redirects to the new one.