### PR TITLE
Add workflow to mirror main to master

### DIFF
--- a/.github/workflows/mirror-main-to-master.yml
+++ b/.github/workflows/mirror-main-to-master.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   mirror-main-to-master:
     runs-on: ubuntu-latest
+    if: github.repository == 'github/vscode-codeql-starter'
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/mirror-main-to-master.yml
+++ b/.github/workflows/mirror-main-to-master.yml
@@ -1,0 +1,17 @@
+# The default branch is "main", but older checkouts may still use "master".
+# This workflow keeps "master" up to date with "main".
+name: Mirror main to master
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  mirror-main-to-master:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Push main to master
+        run: git push origin main:master


### PR DESCRIPTION
Currently we keep "master" up-to-date manually (for users who still have an old checkout), but we can try to automate this instead.