### PR TITLE
Packaging: Update `qlpack.yml` files for packaging

### DIFF
--- a/codeql-custom-queries-cpp/qlpack.yml
+++ b/codeql-custom-queries-cpp/qlpack.yml
@@ -1,3 +1,7 @@
-name: codeql-custom-queries-cpp
+# Change 'getting-started' to the name of a user or organization that you have write access to.
+name: getting-started/codeql-extra-queries-cpp
 version: 0.0.0
-libraryPathDependencies: codeql-cpp
+dependencies:
+  # This uses the latest version of the codeql/cpp-all library.
+  # You may want to change to a more precise semver string.
+  codeql/cpp-all: "*"

--- a/codeql-custom-queries-csharp/qlpack.yml
+++ b/codeql-custom-queries-csharp/qlpack.yml
@@ -1,3 +1,7 @@
-name: codeql-custom-queries-csharp
+# Change 'getting-started' to the name of a user or organization that you have write access to.
+name: getting-started/codeql-extra-queries-csharp
 version: 0.0.0
-libraryPathDependencies: codeql-csharp
+dependencies:
+  # This uses the latest version of the codeql/csharp-all library.
+  # You may want to change to a more precise semver string.
+  codeql/csharp-all: "*"

--- a/codeql-custom-queries-go/qlpack.yml
+++ b/codeql-custom-queries-go/qlpack.yml
@@ -1,3 +1,7 @@
-name: codeql-custom-queries-go
+# Change 'getting-started' to the name of a user or organization that you have write access to.
+name: getting-started/codeql-extra-queries-go
 version: 0.0.0
-libraryPathDependencies: codeql-go
+dependencies:
+  # This uses the latest version of the codeql/go-all library.
+  # You may want to change to a more precise semver string.
+  codeql/go-all: "*"

--- a/codeql-custom-queries-java/qlpack.yml
+++ b/codeql-custom-queries-java/qlpack.yml
@@ -1,3 +1,7 @@
-name: codeql-custom-queries-java
+# Change 'getting-started' to the name of a user or organization that you have write access to.
+name: getting-started/codeql-extra-queries-java
 version: 0.0.0
-libraryPathDependencies: codeql-java
+dependencies:
+  # This uses the latest version of the codeql/java-all library.
+  # You may want to change to a more precise semver string.
+  codeql/java-all: "*"

--- a/codeql-custom-queries-javascript/qlpack.yml
+++ b/codeql-custom-queries-javascript/qlpack.yml
@@ -1,3 +1,7 @@
-name: codeql-custom-queries-javascript
+# Change 'getting-started' to a user name or organization that you have write access to
+name: getting-started/codeql-extra-queries-javascript
 version: 0.0.0
-libraryPathDependencies: codeql-javascript
+dependencies:
+  # This uses the latest version of the codeql/javascript-all library.
+  # You may want to change to a more precise semver string.
+  codeql/javascript-all: "*"

--- a/codeql-custom-queries-python/qlpack.yml
+++ b/codeql-custom-queries-python/qlpack.yml
@@ -1,3 +1,7 @@
-name: codeql-custom-queries-python
+# Change 'getting-started' to a user name or organization that you have write access to
+name: getting-started/codeql-extra-queries-python
 version: 0.0.0
-libraryPathDependencies: codeql-python
+dependencies:
+  # This uses the latest version of the codeql/python-all library.
+  # You may want to change to a more precise semver string.
+  codeql/python-all: "*"


### PR DESCRIPTION
Converts the qlpack.yml files to use the modern packaging
format.

This retains the ql and codeql-qo submodules so that users
are not required to download packages from the registry.
Therefore, the qlpack.lock.yml files are empty since all
dependencies are found locally.