### PR TITLE
Remove mentions of LGTM.com from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,7 @@ A starter workspace to use with the [CodeQL extension for Visual Studio Code](ht
     - Use `git submodule update --remote` regularly to keep the submodules up to date.
 1. In VS Code, click File > Open Workspace. Select the file `vscode-codeql-starter.code-workspace` in your checkout of this repository.
 1. You will see several folders open in the left sidebar:
-    - The `ql` folder contains the [open-source CodeQL standard libraries](https://github.com/github/codeql/tree/codeql-cli/latest) for C/C++, C#, Go, Java, JavaScript/Typescript, Python, and Ruby. It tracks the branch tagged `codeql-cli/latest`. You can run the standard queries from here, and browse the libraries.
-    - The `codeql-go` folder contains the [open-source CodeQL standard libraries](https://github.com/github/codeql-go/tree/codeql-cli/latest) for Go. It tracks the branch tagged `codeql-cli/latest`. You can run the standard queries from here, and browse the libraries.    
+    - The `ql` folder contains the [open-source CodeQL standard libraries](https://github.com/github/codeql/tree/codeql-cli/latest) for C/C++, C#, Go, Java, JavaScript/Typescript, Python, and Ruby. It tracks the branch tagged `codeql-cli/latest` in https://github.com/github/codeql. You can run the standard queries from here, and browse the libraries.
     - The folders named `codeql-custom-queries-<language>` are ready for you to start developing your own custom queries for each language, while using the standard libraries. There are some example queries to get you started.
 1. Follow the [documentation for the CodeQL extension](https://codeql.github.com/docs/codeql-for-visual-studio-code/) to learn how to set up the extension, add a database and run queries against it. Have fun!
 

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ A starter workspace to use with the [CodeQL extension for Visual Studio Code](ht
     - Use `git submodule update --remote` regularly to keep the submodules up to date.
 1. In VS Code, click File > Open Workspace. Select the file `vscode-codeql-starter.code-workspace` in your checkout of this repository.
 1. You will see several folders open in the left sidebar:
-    - The `ql` folder contains the [open-source CodeQL standard libraries](https://github.com/github/codeql/tree/lgtm.com) for C/C++, C#, Java, JavaScript, and Python. It tracks the `lgtm.com` branch. You can run the standard queries from here, and browse the libraries.
-    - The `codeql-go` folder contains the [open-source CodeQL standard libraries](https://github.com/github/codeql-go/tree/lgtm.com) for Go. It tracks the `lgtm.com` branch. You can run the standard queries from here, and browse the libraries.
+    - The `ql` folder contains the [open-source CodeQL standard libraries](https://github.com/github/codeql/tree/codeql-cli/latest) for C/C++, C#, Go, Java, JavaScript/Typescript, Python, and Ruby. It tracks the branch tagged `codeql-cli/latest`. You can run the standard queries from here, and browse the libraries.
+    - The `codeql-go` folder contains the [open-source CodeQL standard libraries](https://github.com/github/codeql-go/tree/codeql-cli/latest) for Go. It tracks the branch tagged `codeql-cli/latest`. You can run the standard queries from here, and browse the libraries.    
     - The folders named `codeql-custom-queries-<language>` are ready for you to start developing your own custom queries for each language, while using the standard libraries. There are some example queries to get you started.
 1. Follow the [documentation for the CodeQL extension](https://codeql.github.com/docs/codeql-for-visual-studio-code/) to learn how to set up the extension, add a database and run queries against it. Have fun!
 


### PR DESCRIPTION
LGTM.com is due to be deprecated (https://github.com/orgs/community/discussions/29534) so this PR updates the readme for the new 'Download database from GitHub' feature.