### PR TITLE
Ruby: Fix compilation of example query

### DIFF
--- a/codeql-custom-queries-ruby/example.ql
+++ b/codeql-custom-queries-ruby/example.ql
@@ -6,6 +6,7 @@
  */
 
 import ruby
+import codeql.ruby.AST
 
 from Block b
 where b.getNumberOfStatements() = 0


### PR DESCRIPTION
The AST library needs to be explicitly imported.