### PR TITLE
Modernize packs

### DIFF
--- a/codeql-custom-queries-cpp/codeql-pack.lock.yml
+++ b/codeql-custom-queries-cpp/codeql-pack.lock.yml
@@ -1,0 +1,4 @@
+---
+lockVersion: 1.0.0
+dependencies: {}
+compiled: false

--- a/codeql-custom-queries-cpp/queries.xml
+++ b/codeql-custom-queries-cpp/queries.xml
@@ -1,1 +1,0 @@
-<queries language="cpp"/>

--- a/codeql-custom-queries-csharp/codeql-pack.lock.yml
+++ b/codeql-custom-queries-csharp/codeql-pack.lock.yml
@@ -1,0 +1,4 @@
+---
+lockVersion: 1.0.0
+dependencies: {}
+compiled: false

--- a/codeql-custom-queries-csharp/queries.xml
+++ b/codeql-custom-queries-csharp/queries.xml
@@ -1,1 +1,0 @@
-<queries language="csharp"/>

--- a/codeql-custom-queries-go/codeql-pack.lock.yml
+++ b/codeql-custom-queries-go/codeql-pack.lock.yml
@@ -1,0 +1,4 @@
+---
+dependencies: {}
+compiled: false
+lockVersion: 1.0.0

--- a/codeql-custom-queries-go/queries.xml
+++ b/codeql-custom-queries-go/queries.xml
@@ -1,1 +1,0 @@
-<queries language="go"/>

--- a/codeql-custom-queries-java/codeql-pack.lock.yml
+++ b/codeql-custom-queries-java/codeql-pack.lock.yml
@@ -1,0 +1,4 @@
+---
+lockVersion: 1.0.0
+dependencies: {}
+compiled: false

--- a/codeql-custom-queries-java/queries.xml
+++ b/codeql-custom-queries-java/queries.xml
@@ -1,1 +1,0 @@
-<queries language="java"/>

--- a/codeql-custom-queries-javascript/codeql-pack.lock.yml
+++ b/codeql-custom-queries-javascript/codeql-pack.lock.yml
@@ -1,0 +1,4 @@
+---
+lockVersion: 1.0.0
+dependencies: {}
+compiled: false

--- a/codeql-custom-queries-javascript/queries.xml
+++ b/codeql-custom-queries-javascript/queries.xml
@@ -1,1 +1,0 @@
-<queries language="javascript"/>

--- a/codeql-custom-queries-python/codeql-pack.lock.yml
+++ b/codeql-custom-queries-python/codeql-pack.lock.yml
@@ -1,0 +1,4 @@
+---
+lockVersion: 1.0.0
+dependencies: {}
+compiled: false

--- a/codeql-custom-queries-python/queries.xml
+++ b/codeql-custom-queries-python/queries.xml
@@ -1,1 +1,0 @@
-<queries language="python"/>

--- a/codeql-custom-queries-ruby/codeql-pack.lock.yml
+++ b/codeql-custom-queries-ruby/codeql-pack.lock.yml
@@ -1,0 +1,4 @@
+---
+dependencies: {}
+compiled: false
+lockVersion: 1.0.0

--- a/codeql-custom-queries-ruby/queries.xml
+++ b/codeql-custom-queries-ruby/queries.xml
@@ -1,1 +1,0 @@
-<queries language="ruby"/>


### PR DESCRIPTION
- Remove `queries.xml`
- Remove `qlpack.lock.yml`
- Add or update `codeql-pack.lock.yml`

Note that the `codeql-pack.lock.yml` all indicate that the dependencies on the core libraries must be available from a source location (ie- in the `ql` submodule).