### PR TITLE
fix: /lib64/ld-linux-x86-64.so.2 not found on arm64 container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,6 +4,7 @@
     "github.vscode-codeql",
     "slevesque.vscode-zipexplorer"
   ],
+  "onCreateCommand": ".devcontainer/oncreate.sh",
   "postCreateCommand": "git submodule init && git submodule update --recursive",
   "settings": {
     "codeQL.runningQueries.memory": 2048

--- a/.devcontainer/oncreate.sh
+++ b/.devcontainer/oncreate.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+UBUNTU_CODENAME=$(lsb_release -c -s)
+echo $UBUNTU_CODENAME
+
+arch="$(dpkg --print-architecture)"
+if [ "$arch" = "arm64" ]; then
+    # Add architecture amd64
+    sudo dpkg --add-architecture amd64
+
+    echo "deb [arch=amd64] http://us.archive.ubuntu.com/ubuntu ${UBUNTU_CODENAME} main restricted
+deb [arch=amd64] http://us.archive.ubuntu.com/ubuntu ${UBUNTU_CODENAME}-updates main restricted
+deb [arch=amd64] http://us.archive.ubuntu.com/ubuntu ${UBUNTU_CODENAME} universe
+deb [arch=amd64] http://us.archive.ubuntu.com/ubuntu ${UBUNTU_CODENAME}-updates universe
+deb [arch=amd64] http://us.archive.ubuntu.com/ubuntu ${UBUNTU_CODENAME} multiverse
+deb [arch=amd64] http://us.archive.ubuntu.com/ubuntu ${UBUNTU_CODENAME}-updates multiverse
+deb [arch=amd64] http://us.archive.ubuntu.com/ubuntu ${UBUNTU_CODENAME}-backports main restricted universe multiverse" \
+    | sudo tee /etc/apt/sources.list.d/cross-source.list
+    
+    # Add default architecture to sources.list, otherwise the 'apt update' command will occurs error
+    sudo sed -i "s/deb/deb [arch=$arch]/g" /etc/apt/sources.list
+
+    # Install libc6:amd64
+    sudo apt update
+    sudo apt install libc6:amd64 -y
+fi


### PR DESCRIPTION
When open the dev container on arm machine, e.g. M1 chip mac, the following error will happen in `CodeQL Extension Log`

```
Resolving RAM settings using CodeQL CLI: resolve ram -v --log-to-stderr --format json --ram 2048...
Failed to run 'codeql version'. Reason: Checking CodeQL version failed: OrbStack ERROR: Dynamic loader not found: /lib64/ld-linux-x86-64.so.2

This usually means that you're running an x86 program on an arm64 OS without multi-arch libraries.
To fix this, you can:
  1. Use an Intel (amd64) container to run this program; or
  2. Install multi-arch libraries in this container.

This can also be caused by running a glibc executable in a musl distro (e.g. Alpine), or vice versa.
```

It can be fix by install an amd64 architecture `libc6` package. I have added a `oncreate.sh` for devcontainer.json on `onCreateCommand` field.