### PR TITLE
Remove the draft-to-ready CI workaround

### DIFF
--- a/.github/workflows/check-submodule-pointers.yml
+++ b/.github/workflows/check-submodule-pointers.yml
@@ -9,7 +9,6 @@ on:
     types:
       - opened
       - synchronize
-      - ready_for_review
       - reopened
   schedule:
     - cron: '42 12 * * *'

--- a/.github/workflows/update-codeql-submodule.yml
+++ b/.github/workflows/update-codeql-submodule.yml
@@ -68,5 +68,4 @@ jobs:
           gh pr create \
             --title "Update CodeQL submodule" \
             --body "Submodule pointer updated from github/codeql@${CODEQL_SHA_BEFORE} to github/codeql@${CODEQL_SHA_AFTER}." \
-            --draft \
             --head "$BRANCH_NAME"


### PR DESCRIPTION
Remove the draft-to-ready CI workaround now that `GITHUB_TOKEN` PRs support check approval, avoiding duplicate checks when drafts are marked ready.